### PR TITLE
added method for revoke token

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -241,4 +241,30 @@ class Provider extends AbstractProvider
 
         return json_decode($value, true);
     }
+
+    /**
+     * @return string
+     */
+    protected function getRevokeUrl(): string
+    {
+        return self::URL.'auth/revoke';
+    }
+
+    /**
+     * @param string $token
+     * @param string $hint
+     * @return \Psr\Http\Message\ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function revokeToken(string $token, string $hint = 'access_token')
+    {
+        return $this->getHttpClient()->post($this->getRevokeUrl(), [
+            RequestOptions::FORM_PARAMS    => [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'token' => $token,
+                'token_type_hint' => $hint
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
Based on the last updates from Apple, where we should add to the user's ability to delete an account, we also should revoke his tokens [(Apple doc).](https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens) So I think will be good to have this ability out of the box, as the "Okta" provider has. [(Okta)](https://socialiteproviders.com/Okta/#installation-basic-usage)